### PR TITLE
Remove Data Type Coupling

### DIFF
--- a/app/src/main/java/com/freedom/yefeng/yfrecyclerview/example/SampleActivity.java
+++ b/app/src/main/java/com/freedom/yefeng/yfrecyclerview/example/SampleActivity.java
@@ -94,7 +94,7 @@ public class SampleActivity extends AppCompatActivity implements YfLoadMoreListe
         if (mLoadingLock) {
             return;
         }
-        if (mAdapter.getData().size() < mTotalDataCount && mAdapter.getData().size() > 0) {
+        if (mAdapter.getDataCount() < mTotalDataCount && mAdapter.getDataCount() > 0) {
             // has more
             mLoadingLock = true;
             if (!mAdapter.getFooters().contains("loading...")) {
@@ -108,7 +108,8 @@ public class SampleActivity extends AppCompatActivity implements YfLoadMoreListe
                     for (int i = 0; i < 20; i++) {
                         moreData.add("item  " + (20 * (mCurrentPage - 1) + i));
                     }
-                    mAdapter.addData(moreData);
+                    mData.addAll(moreData);
+                    mAdapter.notifyCustomDataSetChanged();
                     mLoadingLock = false;
                 }
             }, 3000);
@@ -224,7 +225,8 @@ public class SampleActivity extends AppCompatActivity implements YfLoadMoreListe
                 footerPosition = 0;
                 mAdapter.removeAllHeader();
                 mAdapter.removeAllFooters();
-                mAdapter.setData(null);
+                mData.clear();
+                mAdapter.notifyAllDataSetChanged();
                 return true;
             case R.id.action_set_data:
                 mCurrentPage = 1;
@@ -236,7 +238,7 @@ public class SampleActivity extends AppCompatActivity implements YfLoadMoreListe
                 footerPosition = 0;
                 mAdapter.removeAllHeader();
                 mAdapter.removeAllFooters();
-                mAdapter.setData(mData);
+                mAdapter.notifyAllDataSetChanged();
                 return true;
 
         }

--- a/app/src/main/java/com/freedom/yefeng/yfrecyclerview/example/SampleGridActivity.java
+++ b/app/src/main/java/com/freedom/yefeng/yfrecyclerview/example/SampleGridActivity.java
@@ -18,9 +18,7 @@ import com.freedom.yefeng.yfrecyclerview.YfListInterface;
 import com.freedom.yefeng.yfrecyclerview.YfListMode;
 import com.freedom.yefeng.yfrecyclerview.YfListRecyclerView;
 import com.freedom.yefeng.yfrecyclerview.YfLoadMoreListener;
-import com.freedom.yefeng.yfrecyclerview.example.adapter.SimpleAdapter;
 import com.freedom.yefeng.yfrecyclerview.example.adapter.SimpleMultiTypeAdapter;
-import com.freedom.yefeng.yfrecyclerview.util.YfListItemType;
 import com.freedom.yefeng.yfrecyclerview.util.YfSpanSizeLookup;
 
 import java.util.ArrayList;
@@ -141,7 +139,7 @@ public class SampleGridActivity extends AppCompatActivity implements YfLoadMoreL
         if (mLoadingLock) {
             return;
         }
-        if (mAdapter.getData().size() < mTotalDataCount && mAdapter.getData().size() > 0) {
+        if (mAdapter.getDataCount() < mTotalDataCount && mAdapter.getDataCount() > 0) {
             // has more
             mLoadingLock = true;
             if (!mAdapter.getFooters().contains("loading...")) {
@@ -158,7 +156,8 @@ public class SampleGridActivity extends AppCompatActivity implements YfLoadMoreL
                         String title = "item  " + (20 * (mCurrentPage - 1) + i);
                         moreData.add(new DemoData(title, type));
                     }
-                    mAdapter.addData(moreData);
+                    mData.addAll(moreData);
+                    mAdapter.notifyCustomDataSetChanged();
                     mLoadingLock = false;
                 }
             }, 3000);
@@ -274,7 +273,8 @@ public class SampleGridActivity extends AppCompatActivity implements YfLoadMoreL
                 footerPosition = 0;
                 mAdapter.removeAllHeader();
                 mAdapter.removeAllFooters();
-                mAdapter.setData(null);
+                mData.clear();
+                mAdapter.notifyAllDataSetChanged();
                 return true;
             case R.id.action_set_data:
                 mCurrentPage = 1;
@@ -286,7 +286,8 @@ public class SampleGridActivity extends AppCompatActivity implements YfLoadMoreL
                 footerPosition = 0;
                 mAdapter.removeAllHeader();
                 mAdapter.removeAllFooters();
-                mAdapter.setData(mData);
+
+                mAdapter.notifyCustomDataSetChanged();
                 return true;
             case R.id.action_switch_list_and_grid:
                 int type = managerType;
@@ -295,7 +296,7 @@ public class SampleGridActivity extends AppCompatActivity implements YfLoadMoreL
                     type = TYPE_LINEAR;
                 }
                 changeLayoutManage(type);
-                mAdapter.notifyDataSetChanged();
+                mAdapter.notifyAllDataSetChanged();
                 return true;
         }
         return super.onOptionsItemSelected(item);
@@ -313,7 +314,7 @@ public class SampleGridActivity extends AppCompatActivity implements YfLoadMoreL
         }
     }
 
-    public static class DemoData implements YfListItemType
+    public static class DemoData
     {
         String data;
         int type;
@@ -327,7 +328,6 @@ public class SampleGridActivity extends AppCompatActivity implements YfLoadMoreL
             return data;
         }
 
-        @Override
         public int getItemType() {
             return this.type;
         }

--- a/app/src/main/java/com/freedom/yefeng/yfrecyclerview/example/adapter/DemoAdapter.java
+++ b/app/src/main/java/com/freedom/yefeng/yfrecyclerview/example/adapter/DemoAdapter.java
@@ -11,15 +11,24 @@ import com.freedom.yefeng.yfrecyclerview.YfSimpleViewHolder;
 import com.freedom.yefeng.yfrecyclerview.example.R;
 
 import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Created by yefeng on 8/5/15.
  * github:yefengfreedom
  */
-public class DemoAdapter extends YfListAdapter<String> {
+public class DemoAdapter extends YfListAdapter {
+
+    List<String> mData;
 
     public DemoAdapter(ArrayList<String> data) {
         super(data);
+        this.mData = data;
+    }
+
+    @Override
+    public int getDataCount() {
+        return null != this.mData ? this.mData.size() : 0;
     }
 
     @Override

--- a/app/src/main/java/com/freedom/yefeng/yfrecyclerview/example/adapter/MenuAdapter.java
+++ b/app/src/main/java/com/freedom/yefeng/yfrecyclerview/example/adapter/MenuAdapter.java
@@ -11,15 +11,24 @@ import com.freedom.yefeng.yfrecyclerview.YfSimpleViewHolder;
 import com.freedom.yefeng.yfrecyclerview.example.R;
 
 import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Created by yefeng on 8/6/15.
  * github:yefengfreedom
  */
-public class MenuAdapter extends YfListAdapter<String> {
+public class MenuAdapter extends YfListAdapter {
+
+    List<String> mData;
 
     public MenuAdapter(ArrayList<String> data) {
         super(data);
+        this.mData = data;
+    }
+
+    @Override
+    public int getDataCount() {
+        return null != this.mData ? this.mData.size() : 0;
     }
 
     @Override

--- a/app/src/main/java/com/freedom/yefeng/yfrecyclerview/example/adapter/RcyInRcyInsideAdapter.java
+++ b/app/src/main/java/com/freedom/yefeng/yfrecyclerview/example/adapter/RcyInRcyInsideAdapter.java
@@ -11,15 +11,24 @@ import com.freedom.yefeng.yfrecyclerview.YfSimpleViewHolder;
 import com.freedom.yefeng.yfrecyclerview.example.R;
 
 import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Created by yefeng on 8/5/15.
  * github:yefengfreedom
  */
-public class RcyInRcyInsideAdapter extends YfListAdapter<String> {
+public class RcyInRcyInsideAdapter extends YfListAdapter {
+
+    List<String> mData;
 
     public RcyInRcyInsideAdapter(ArrayList<String> data) {
         super(data);
+        this.mData = data;
+    }
+
+    @Override
+    public int getDataCount() {
+        return null != this.mData ? this.mData.size() : 0;
     }
 
     @Override

--- a/app/src/main/java/com/freedom/yefeng/yfrecyclerview/example/adapter/RcyInRcyOutAdapter.java
+++ b/app/src/main/java/com/freedom/yefeng/yfrecyclerview/example/adapter/RcyInRcyOutAdapter.java
@@ -14,16 +14,24 @@ import com.freedom.yefeng.yfrecyclerview.YfSimpleViewHolder;
 import com.freedom.yefeng.yfrecyclerview.example.R;
 
 import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Created by yefeng on 8/5/15.
  * github:yefengfreedom
  */
-public class RcyInRcyOutAdapter extends YfListAdapter<String> {
+public class RcyInRcyOutAdapter extends YfListAdapter {
 
+    ArrayList<String> mData;
 
     public RcyInRcyOutAdapter(ArrayList<String> data) {
         super(data);
+        this.mData = data;
+    }
+
+    @Override
+    public int getDataCount() {
+        return null != this.mData ? this.mData.size() : 0;
     }
 
     @Override

--- a/app/src/main/java/com/freedom/yefeng/yfrecyclerview/example/adapter/SimpleAdapter.java
+++ b/app/src/main/java/com/freedom/yefeng/yfrecyclerview/example/adapter/SimpleAdapter.java
@@ -11,15 +11,24 @@ import com.freedom.yefeng.yfrecyclerview.YfSimpleViewHolder;
 import com.freedom.yefeng.yfrecyclerview.example.R;
 
 import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Created by yefeng on 8/5/15.
  * github:yefengfreedom
  */
-public class SimpleAdapter extends YfListAdapter<String> {
+public class SimpleAdapter extends YfListAdapter {
+
+    List<String> mData;
 
     public SimpleAdapter(ArrayList<String> data) {
         super(data);
+        this.mData = data;
+    }
+
+    @Override
+    public int getDataCount() {
+        return null != this.mData ? this.mData.size() : 0;
     }
 
     @Override
@@ -66,7 +75,6 @@ public class SimpleAdapter extends YfListAdapter<String> {
         ((FooterViewHolder) holder).mText.setText(footer);
         holder.itemView.setTag(footer);
     }
-
 
     @Override
     public RecyclerView.ViewHolder onCreateErrorViewHolder(ViewGroup parent) {

--- a/app/src/main/java/com/freedom/yefeng/yfrecyclerview/example/adapter/SimpleMultiTypeAdapter.java
+++ b/app/src/main/java/com/freedom/yefeng/yfrecyclerview/example/adapter/SimpleMultiTypeAdapter.java
@@ -13,19 +13,32 @@ import com.freedom.yefeng.yfrecyclerview.example.R;
 import com.freedom.yefeng.yfrecyclerview.example.SampleGridActivity;
 
 import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Created by KingWu on 23/10/15
  * github: github.com/KingWu
  */
-public class SimpleMultiTypeAdapter extends YfMultiTypeListAdapter<SampleGridActivity.DemoData> {
+public class SimpleMultiTypeAdapter extends YfMultiTypeListAdapter{
 
     public final static int BASE_TYPE = 10;
     public final static int NUMBER_OF_TYPE = 4;
+    List<SampleGridActivity.DemoData> mData;
 
 
     public SimpleMultiTypeAdapter(ArrayList<SampleGridActivity.DemoData> data) {
         super(data);
+        this.mData = data;
+    }
+
+    @Override
+    public int getCustomItemType(int position) {
+        return mData.get(position).getItemType();
+    }
+
+    @Override
+    public int getDataCount() {
+        return mData.size();
     }
 
     @Override
@@ -83,7 +96,6 @@ public class SimpleMultiTypeAdapter extends YfMultiTypeListAdapter<SampleGridAct
         ((FooterViewHolder) holder).mText.setText(footer);
         holder.itemView.setTag(footer);
     }
-
 
     @Override
     public RecyclerView.ViewHolder onCreateErrorViewHolder(ViewGroup parent) {

--- a/yf_list_recycler_view/src/main/java/com/freedom/yefeng/yfrecyclerview/YfListRecyclerView.java
+++ b/yf_list_recycler_view/src/main/java/com/freedom/yefeng/yfrecyclerview/YfListRecyclerView.java
@@ -25,7 +25,7 @@ public class YfListRecyclerView extends RecyclerView {
     private LinearLayoutManager mLayoutManager;
     private Adapter mAdapter;
     private YfLoadMoreListener yfLoadMoreListener;
-
+    private boolean mLoadingLock = false;
 
     public YfListRecyclerView(Context context) {
         super(context);
@@ -43,6 +43,10 @@ public class YfListRecyclerView extends RecyclerView {
         @Override
         public void onScrolled(RecyclerView recyclerView, int dx, int dy) {
             super.onScrolled(recyclerView, dx, dy);
+            if(mLoadingLock){
+               return;
+            }
+
             if (null == mLayoutManager || null == mAdapter) {
                 return;
             }
@@ -50,6 +54,7 @@ public class YfListRecyclerView extends RecyclerView {
             mTotalItemCount = mLayoutManager.getItemCount();
             mFirstVisibleItemPosition = mLayoutManager.findFirstVisibleItemPosition();
             if ((mVisibleItemCount + mFirstVisibleItemPosition) >= mTotalItemCount) {
+                mLoadingLock = true;
                 if (null != yfLoadMoreListener) {
                     LogUtil.d(TAG, "loadMore");
                     yfLoadMoreListener.loadMore();
@@ -141,6 +146,10 @@ public class YfListRecyclerView extends RecyclerView {
     public void setLayoutManager(LayoutManager layout) {
         this.mLayoutManager = (LinearLayoutManager) layout;
         super.setLayoutManager(this.mLayoutManager);
+    }
+
+    public void disableLoadingLock() {
+        this.mLoadingLock = false;
     }
 
     /**

--- a/yf_list_recycler_view/src/main/java/com/freedom/yefeng/yfrecyclerview/YfListRecyclerView.java
+++ b/yf_list_recycler_view/src/main/java/com/freedom/yefeng/yfrecyclerview/YfListRecyclerView.java
@@ -24,6 +24,8 @@ public class YfListRecyclerView extends RecyclerView {
     private int mVisibleItemCount, mTotalItemCount, mFirstVisibleItemPosition;
     private LinearLayoutManager mLayoutManager;
     private Adapter mAdapter;
+    private YfLoadMoreListener yfLoadMoreListener;
+
 
     public YfListRecyclerView(Context context) {
         super(context);
@@ -36,6 +38,26 @@ public class YfListRecyclerView extends RecyclerView {
     public YfListRecyclerView(Context context, AttributeSet attrs, int defStyle) {
         super(context, attrs, defStyle);
     }
+
+    private RecyclerView.OnScrollListener recyclerViewLoadMore = new RecyclerView.OnScrollListener() {
+        @Override
+        public void onScrolled(RecyclerView recyclerView, int dx, int dy) {
+            super.onScrolled(recyclerView, dx, dy);
+            if (null == mLayoutManager || null == mAdapter) {
+                return;
+            }
+            mVisibleItemCount = mLayoutManager.getChildCount();
+            mTotalItemCount = mLayoutManager.getItemCount();
+            mFirstVisibleItemPosition = mLayoutManager.findFirstVisibleItemPosition();
+            if ((mVisibleItemCount + mFirstVisibleItemPosition) >= mTotalItemCount) {
+                if (null != yfLoadMoreListener) {
+                    LogUtil.d(TAG, "loadMore");
+                    yfLoadMoreListener.loadMore();
+                }
+            }
+        }
+    };
+
 
 
     /**
@@ -126,24 +148,17 @@ public class YfListRecyclerView extends RecyclerView {
      *
      * @param loadMoreListener load more listener
      */
-    public void enableAutoLoadMore(final YfLoadMoreListener loadMoreListener) {
-        addOnScrollListener(new RecyclerView.OnScrollListener() {
-            @Override
-            public void onScrolled(RecyclerView recyclerView, int dx, int dy) {
-                super.onScrolled(recyclerView, dx, dy);
-                if (null == mLayoutManager || null == mAdapter) {
-                    return;
-                }
-                mVisibleItemCount = mLayoutManager.getChildCount();
-                mTotalItemCount = mLayoutManager.getItemCount();
-                mFirstVisibleItemPosition = mLayoutManager.findFirstVisibleItemPosition();
-                if ((mVisibleItemCount + mFirstVisibleItemPosition) >= mTotalItemCount) {
-                    if (null != loadMoreListener) {
-                        LogUtil.d(TAG, "loadMore");
-                        loadMoreListener.loadMore();
-                    }
-                }
-            }
-        });
+    public void enableAutoLoadMore(YfLoadMoreListener loadMoreListener) {
+
+        if(null == this.yfLoadMoreListener){
+            this.yfLoadMoreListener = loadMoreListener;
+            addOnScrollListener(recyclerViewLoadMore);
+        }
+    }
+
+    public void disenableAutoLoadMore()
+    {
+        this.yfLoadMoreListener = null;
+        removeOnScrollListener(recyclerViewLoadMore);
     }
 }

--- a/yf_list_recycler_view/src/main/java/com/freedom/yefeng/yfrecyclerview/YfMultiTypeListAdapter.java
+++ b/yf_list_recycler_view/src/main/java/com/freedom/yefeng/yfrecyclerview/YfMultiTypeListAdapter.java
@@ -2,13 +2,11 @@ package com.freedom.yefeng.yfrecyclerview;
 
 import android.os.Handler;
 import android.support.v7.widget.RecyclerView;
-import android.util.Log;
 import android.view.View;
 import android.view.ViewGroup;
 
-import com.freedom.yefeng.yfrecyclerview.util.YfListItemType;
-
 import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Created by KingWu on 23/10/15
@@ -22,21 +20,21 @@ import java.util.ArrayList;
  *      MODE_HEADER_VIEW = 4
  *      MODE_FOOTER_VIEW = 5
  */
-public abstract class YfMultiTypeListAdapter<T extends YfListItemType> extends YfListAdapter<T> {
+public abstract class YfMultiTypeListAdapter extends YfListAdapter {
 
-    public YfMultiTypeListAdapter(ArrayList<T> data) {
+    public YfMultiTypeListAdapter(List<?> data) {
         super(data);
     }
 
-    public YfMultiTypeListAdapter(ArrayList<T> data, int mode) {
+    public YfMultiTypeListAdapter(List<?> data, int mode) {
         super(data, mode);
     }
 
-    public YfMultiTypeListAdapter(ArrayList<T> data, int mode, int toolBarHeight) {
+    public YfMultiTypeListAdapter(List<?> data, int mode, int toolBarHeight) {
         super(data, mode, toolBarHeight);
     }
 
-    public YfMultiTypeListAdapter(ArrayList<T> data, ArrayList<Object> headers, ArrayList<Object> footers, int mode, int toolBarHeight) {
+    public YfMultiTypeListAdapter(List<?> data, ArrayList<Object> headers, ArrayList<Object> footers, int mode, int toolBarHeight) {
         super(data, headers, footers, mode, toolBarHeight);
     }
 
@@ -44,14 +42,10 @@ public abstract class YfMultiTypeListAdapter<T extends YfListItemType> extends Y
     public int getItemViewType(int position) {
         int itemType = super.getItemViewType(position);
 
-        Log.d("", "position : " + position);
-        Log.d("", "itemType : " + itemType);
-
-
         if(itemType != YfListMode.MODE_DATA){
             return itemType;
         }
-        return super.getData().get(getDataOffsetPosition(position)).getItemType();
+        return getCustomItemType(getDataOffsetPosition(position));
     }
 
     @Override
@@ -59,7 +53,7 @@ public abstract class YfMultiTypeListAdapter<T extends YfListItemType> extends Y
         super.onBindViewHolder(holder, position);
 
         int headerCount = mHeaders.size();
-        if (position >= headerCount && position < headerCount + mData.size()) {
+        if (position >= headerCount && position < headerCount + getDataCount()) {
             onBindCustomDataViewHolder(holder, getDataOffsetPosition(position));
         }
     }
@@ -189,6 +183,8 @@ public abstract class YfMultiTypeListAdapter<T extends YfListItemType> extends Y
         });
         return dataViewHolder;
     }
+
+    public abstract int getCustomItemType(int position);
 
     public abstract void onBindCustomDataViewHolder(RecyclerView.ViewHolder holder, int position);
 

--- a/yf_list_recycler_view/src/main/java/com/freedom/yefeng/yfrecyclerview/util/YfListItemType.java
+++ b/yf_list_recycler_view/src/main/java/com/freedom/yefeng/yfrecyclerview/util/YfListItemType.java
@@ -1,8 +1,0 @@
-package com.freedom.yefeng.yfrecyclerview.util;
-
-/**
- * Created by KingWu on 23/10/15.
- */
-public interface YfListItemType {
-    int getItemType();
-}

--- a/yf_list_recycler_view/src/main/java/com/freedom/yefeng/yfrecyclerview/util/YfSpanSizeLookup.java
+++ b/yf_list_recycler_view/src/main/java/com/freedom/yefeng/yfrecyclerview/util/YfSpanSizeLookup.java
@@ -24,7 +24,7 @@ public class YfSpanSizeLookup extends GridLayoutManager.SpanSizeLookup {
         int headerCount = adapter.getHeaderCount();
         if (position < headerCount) {
             return spanCount;
-        } else if (position >= headerCount + adapter.getData().size()) {
+        } else if (position >= headerCount + adapter.getDataCount()) {
             return spanCount;
         }
         return 1;


### PR DESCRIPTION
Remove Generic Type on YfListAdapter as Data type coupling. Library users cannot be easy to switch different data list with different data structures. 

Add Features on YfListAdapter
- notifyAllDataSetChanged [Notice headers, footers and custom data set to update UI]
- notifyCustomDataSetChanged [Notice all custom data set to update UI]
